### PR TITLE
Fixed bug with taking Max of negative data

### DIFF
--- a/src/sta.cpp
+++ b/src/sta.cpp
@@ -39,7 +39,7 @@ static int all_flag;
 /* VARIABLES */
 string delimiter = "\t";
 
-long double N = 0, Min = LDBL_MAX, Max = LDBL_MIN, sum = 0;
+long double N = 0, Min = LDBL_MAX, Max = -LDBL_MAX, sum = 0;
 
 /* DATA STRUCTURES */
 vector<long double> points;


### PR DESCRIPTION
Hi - great program, but MAX was giving LDBL_MIN (nearly  zero) for negative data