### PR TITLE
sta: fix build against gcc-11.2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,9 @@ void print_stats(Sta* sta){
 	if(percentiles_flag){
 		map<double, long double> percentiles = sta->get_percentiles();
 		for(map<double,long double>::iterator ii = percentiles.begin(); ii != percentiles.end(); ++ii){
-			string String = static_cast<ostringstream*>( &(ostringstream() << ii->first) )->str();
+			ostringstream os;
+			os << ii->first;
+			string String = os.str();
 			opts_ordered.push_back(String + "th");
 			opts[String + "th"] = 1;
 		}

--- a/src/sta.cpp
+++ b/src/sta.cpp
@@ -52,7 +52,9 @@ void Sta::compute_quartiles(){
 void Sta::compute_percentile(double p){
 	double percentile = (p/100) * points.size();
 	nth_element( points.begin(), points.begin()+percentile, points.end() );
-	string String = static_cast<ostringstream*>( &(ostringstream() << p) )->str();
+	ostringstream os;
+	os << p;
+	string String = os.str();
 	global_stats[String + "th"] = points[percentile]; 
 }
 


### PR DESCRIPTION
On gcc-11.2 build fails as:

    src/main.cpp: In function 'void print_stats(Sta*)':
    src/main.cpp:91:88: error: taking address of rvalue [-fpermissive]
       91 |                         string String = static_cast<ostringstream*>( &(ostringstream() << ii->first) )-

Fix build by simplifying expression to convert to string.